### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ d<sup>2</sup> = (r<sub>1</sub>-r<sub>2</sub>)<sup>2</sup>+(g<sub>1</sub>-g<sub>2
 ## what do I do with the generated commands?
 
 minecraft datapacks support putting up to 65536 commands to a .mcfunction file. If you don't know much about creating datapacks,
-[here's more details](https://minecraft.fandom.com/wiki/Data_pack) or you can download this [sample data pack](/public/sample_datapack.zip) and put the generated commands to a file in /data/sample_datapack/functions/ and add the datapack to your world.
+[here's more details](https://minecraft.wiki/w/Data_pack) or you can download this [sample data pack](/public/sample_datapack.zip) and put the generated commands to a file in /data/sample_datapack/functions/ and add the datapack to your world.
 
 #### That's all, here are some screenshots, that bring me joy
 

--- a/about.html
+++ b/about.html
@@ -54,7 +54,7 @@ It'd be possible to pick between many such lists to e.g. only use blocks easily 
 which can be calculated from their r, g, b values: d<sup>2</sup> = (r<sub>1</sub>-r<sub>2</sub>)<sup>2</sup>+(g<sub>1</sub>-g<sub>2</sub>)^2+(b<sub>1</sub>-b<sub>2</sub>)<sup>2</sup></p>
 <h2>what do I do with the generated commands?</h2>
 <p>minecraft datapacks support putting up to 65536 commands to a .mcfunction file. If you don't know much about creating datapacks,
-<a href="https://minecraft.fandom.com/wiki/Data_pack">here's more details</a> or you can download this <a href="/public/sample_datapack.zip">sample data pack</a> and put the generated commands to a file in /data/sample_datapack/functions/ and add the datapack to your world.</p>
+<a href="https://minecraft.wiki/w/Data_pack">here's more details</a> or you can download this <a href="/public/sample_datapack.zip">sample data pack</a> and put the generated commands to a file in /data/sample_datapack/functions/ and add the datapack to your world.</p>
 <p>That's all, here are some screenshots, that bring me joy</p>
 <img src="/public/images/screenshots/globe.png"/>
 <img src="/public/images/screenshots/monke.png"/>

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -137,7 +137,7 @@ class AboutPage extends Component {
         <p>
           minecraft datapacks support putting up to 65536 commands to a
           .mcfunction file. If you don't know much about creating datapacks,
-          <a href="https://minecraft.fandom.com/wiki/Data_pack">
+          <a href="https://minecraft.wiki/w/Data_pack">
             here's more details
           </a>{" "}
           or you can download this{" "}


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki